### PR TITLE
Pull-request: abilty to query bindings by parameterized types

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -4,5 +4,5 @@ project.organization=org.scala-tools
 project.name=subcut
 sbt.version=0.7.7
 project.version=0.9-SNAPSHOT
-build.scala.versions=2.9.0 2.8.0 2.8.1
+build.scala.versions=2.9.1 2.9.0-1 2.9.0 2.8.1 2.8.0
 project.initialize=false

--- a/src/main/scala/org/scala_tools/subcut/inject/Injectable.scala
+++ b/src/main/scala/org/scala_tools/subcut/inject/Injectable.scala
@@ -17,7 +17,7 @@ trait Injectable {
    * @return an instance configured by the binding module to use for the given trait.
    */
   def inject[T <: Any](implicit m: scala.reflect.Manifest[T]): T =
-    bindingModule.inject(m.erasure.asInstanceOf[Class[T]], None)
+    bindingModule.inject[T](None)
 
   /**
    * Inject an instance for the given trait based on the class type required and an ID symbol. If there is no
@@ -28,7 +28,7 @@ trait Injectable {
    * @return an instance configured by the binding module to use for the given trait and ID
    */
   def inject[T <: Any](symbol: Symbol)(implicit m: scala.reflect.Manifest[T]): T =
-    bindingModule.inject(m.erasure.asInstanceOf[Class[T]], Some(symbol.name))
+    bindingModule.inject[T](Some(symbol.name))
 
   /**
    * Inject an instance for the given trait based on the class type required and an ID string. If there is no
@@ -39,7 +39,7 @@ trait Injectable {
    * @return an instance configured by the binding module to use for the given trait and ID
    */
   def inject[T <: Any](name: String)(implicit m: scala.reflect.Manifest[T]): T =
-    bindingModule.inject(m.erasure.asInstanceOf[Class[T]], Some(name))
+    bindingModule.inject[T](Some(name))
 
   /**
    * Inject an instance for the given trait based on the class type only if there is no instance already provided.
@@ -90,7 +90,7 @@ trait Injectable {
    * function if no matching binding is defined.
    */
   def injectIfBound[T <: Any](fn: => T)(implicit m: scala.reflect.Manifest[T]): T = {
-    bindingModule.injectOptional(m.erasure.asInstanceOf[Class[Any]], None) match {
+    bindingModule.injectOptional[T](None) match {
       case None => // must then have a valid impltouse
         val implToUse = fn
         if (implToUse == null)
@@ -112,7 +112,7 @@ trait Injectable {
    * function if no matching binding is defined.
    */
   def injectIfBound[T <: Any](name: String)(fn: => T)(implicit m: scala.reflect.Manifest[T]): T = {
-    bindingModule.injectOptional(m.erasure.asInstanceOf[Class[Any]], Some(name)) match {
+    bindingModule.injectOptional[T](Some(name)) match {
       case None => // must then have a valid impltouse
         val implToUse = fn
         if (implToUse == null)

--- a/src/test/scala/org/scala_tools/subcut/inject/PlainScalaInjectInBindingTest.scala
+++ b/src/test/scala/org/scala_tools/subcut/inject/PlainScalaInjectInBindingTest.scala
@@ -8,19 +8,19 @@ import org.scalatest.FunSuite
 class PlainScalaInjectInBindingTest extends FunSuite with ShouldMatchers {
 
   test("inject method is used as service locator for plain Scala constructor style dependency injection during binding") {
-	  val client = EchoModule.inject(classOf[EchoClient],Some("constructorStyle"))
+	  val client = EchoModule.inject[EchoClient](Some("constructorStyle"))
 	  val result = client.callEcho("Hallooo")
 	  result should equal ("Hallooo Constructor Style")	  
   } 
   
   test("inject method is used as service locator for plain Scala def override style dependency injection during binding") {
-	  val client = EchoModule.inject(classOf[EchoClient],Some("defOverrideStyle"))
+	  val client = EchoModule.inject[EchoClient](Some("defOverrideStyle"))
 	  val result = client.callEcho("Hallooo")
 	  result should equal ("Hallooo Def Override Style")	  
   }  
   
   test("inject method is used as service locator for plain Scala property style dependency injection during binding") {
-	  val client = EchoModule.inject(classOf[EchoClient],Some("propertyStyle"))
+	  val client = EchoModule.inject[EchoClient](Some("propertyStyle"))
 	  val result = client.callEcho("Hallooo")
 	  result should equal ("Hallooo Property Style")	  
   }  

--- a/src/test/scala/org/scala_tools/subcut/inject/TypeErasureTest.scala
+++ b/src/test/scala/org/scala_tools/subcut/inject/TypeErasureTest.scala
@@ -1,0 +1,31 @@
+package org.scala_tools.subcut.inject
+
+import org.scalatest.{SeveredStackTraces, FunSuite}
+import org.scalatest.matchers.ShouldMatchers
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TypeErasureTest extends FunSuite with ShouldMatchers with SeveredStackTraces {
+  test("Can inject types regardless of erasure in binding keys") {
+    val actual = new Injectable {
+      val bindingModule = TypeErasureModule
+      val intList = inject[List[Int]]
+      val stringList = inject[List[String]]
+      val intListOfListsFoo = inject[List[List[Int]]] { "foo" }
+      val stringListOfListsFoo = inject[List[List[String]]] { "foo" }
+    }
+    actual.intList should be { List(1, 2, 3) }
+    actual.stringList should be { List("a", "b", "c") }
+    actual.intListOfListsFoo should be { List(List(1, 2, 3)) }
+    actual.stringListOfListsFoo should be { List(List("a", "b", "c")) }
+  }
+}
+
+object TypeErasureModule extends NewBindingModule({ module =>
+  import module._
+  bind[List[Int]] toInstance { List(1, 2, 3) }
+  bind[List[String]] toInstance { List("a", "b", "c") }
+  bind[List[List[Int]]] identifiedBy "foo" toInstance { List(List(1, 2, 3)) }
+  bind[List[List[String]]] identifiedBy "foo" toInstance { List(List("a", "b", "c")) }
+})


### PR DESCRIPTION
Added TypeErasureTest and changed BindingKey to include manifest (to allow for injection of parameterized types)

Have been using for a month or so now.  Manifest-in-BindingKey trick was scraped from this SO:

http://stackoverflow.com/questions/1094173/how-do-i-get-around-type-erasure-on-scala-or-why-cant-i-get-the-type-parameter 

Allan
