### PR TITLE
Injection via extractor

### DIFF
--- a/src/main/scala/org/scala_tools/subcut/inject/Injectable.scala
+++ b/src/main/scala/org/scala_tools/subcut/inject/Injectable.scala
@@ -167,6 +167,10 @@ trait Injectable {
   def injectOptional[T <: Any](name: String)(implicit m: scala.reflect.Manifest[T]): Option[T] =
     bindingModule.injectOptional[T](Some(name))
 
+  object Inject { 
+    def unapply[T <: Any](implicit m: scala.reflect.Manifest[T]): Option[T] =
+      Some(inject[T]/*(m)*/)
+  }
 }
 
 /**

--- a/src/test/scala/org/scala_tools/subcut/inject/PlainScalaInjectInBindingTest.scala
+++ b/src/test/scala/org/scala_tools/subcut/inject/PlainScalaInjectInBindingTest.scala
@@ -24,6 +24,13 @@ class PlainScalaInjectInBindingTest extends FunSuite with ShouldMatchers {
 	  val result = client.callEcho("Hallooo")
 	  result should equal ("Hallooo Property Style")	  
   }  
+
+  test("inject using extractor") {
+    import EchoModule._
+	  val Inject(service) = manifest[EchoService]
+	  val result = service.echo("test")
+	  result should equal ("test")
+  }  
   
   
   class EchoService {


### PR DESCRIPTION
Hi,

I toyed with using extractors for dependency injection -- I'm not sure how useful it would be (if not then it should be abandoned), but thought I'd share anyway.
An interesting use case could be to enable dependency injection to occur as part of pattern matching, but I haven't tried that yet.

This is what I came up with:

``` scala
val Inject(service) = manifest[EchoService]
```

The extractor Inject was added at Injectable, and I placed a minimal test along with  PlainScalaInjectInBindingTest.

This could be further extended to drop mention of 'manifest[...]' from user code, and to allow inject by id as well.
