### PR TITLE
Remove duplicated name tag from pom file.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
 pomExtra := <xml:group>
     <inceptionYear>2011</inceptionYear>
-    <name>Scala Uniquely Bound Classes Under Traits: SubCut</name>
     <description>
+      Scala Uniquely Bound Classes Under Traits: SubCut.
       A simple, lightweight and convenient way to inject dependencies
       in scala, in a scala-like way.
     </description>


### PR DESCRIPTION
I am using Artifactory as proxy repo and it can't parse subcut pom file:

" Failed to download 'https://oss.sonatype.org/content/groups/public/com/escalatesoft/subcut/subcut_2.9.1/2.0-SNAPSHOT/subcut_2.9.1-2.0-SNAPSHOT.pom'. Received status code 200 and caught exception: Failed to read POM for 'com/escalatesoft/subcut/subcut_2.9.1/2.0-SNAPSHOT/subcut_2.9.1-2.0-SNAPSHOT.pom': Duplicated tag: 'name' (position: START_TAG seen ...</inceptionYear>\n    <name>... @14:11) ."

So I removed this tag. And move content to the description tag. It would be great if you can republish fixed snapshot.

Thanks, Artem.
