### PR TITLE
Initial update for TypedBindingId support

### DIFF
--- a/src/main/scala/com/escalatesoft/subcut/inject/BindingId.scala
+++ b/src/main/scala/com/escalatesoft/subcut/inject/BindingId.scala
@@ -23,3 +23,11 @@ abstract class BindingId {
     if (shortName.last == '$') shortName.init else shortName
   }
 }
+
+abstract class TypedBindingId[T] {
+  lazy val bindingName = {
+    val shortName = this.getClass.getSimpleName
+    // strip the trailing $ for objects
+    if (shortName.last == '$') shortName.init else shortName
+  }
+}

--- a/src/main/scala/com/escalatesoft/subcut/inject/BindingModule.scala
+++ b/src/main/scala/com/escalatesoft/subcut/inject/BindingModule.scala
@@ -618,6 +618,7 @@ trait MutableBindingModule extends BindingModule { outer =>
      * @param name the string name to identify the binding when used in combination with the type parameter.
      */
     def idBy(name: String) = identifiedBy(name)
+    def idBy(id: TypedBindingId[T]) = identifiedBy(id.bindingName)
   }
 
   // and a parameterized bind method to kick it all off

--- a/src/test/scala/com/escalatesoft/subcut/inject/BindingIdObjectsTest.scala
+++ b/src/test/scala/com/escalatesoft/subcut/inject/BindingIdObjectsTest.scala
@@ -43,7 +43,8 @@ class BindingIdObjectsTest extends FunSuite with Matchers {
       import module._
       bind [String] idBy Mammal toSingle "Cheetah"
       bind [String] idBy Role toSingle "Run"
-      bind [String] idBy Vehicle toSingle "Gallop"
+//      bind [String] idBy Vehicle toSingle "Gallop"
+      bind [String] idBy PoolSize toSingle "Gallop"
     }
 
     val mtd = new Speedway
@@ -55,6 +56,7 @@ class BindingIdObjectsTest extends FunSuite with Matchers {
 object Vehicle extends BindingId
 object Role extends BindingId
 object Mammal extends BindingId
+object PoolSize extends TypedBindingId[Int]
 
 class Speedway(implicit val bindingModule: BindingModule) extends Injectable {
   val mammal = inject[String](Mammal)


### PR DESCRIPTION
I really like subcut. Great Job. I have a small enhancement how to make subcut type safer. When we use BindingId for defining/injecting primitives or special objects then we could make mistakes and use wrong id object. In this case compiler will not catch the mistake and we will learn it during runtime. The below approach allow us to catch some errors during compilation stage.

It defines a new abstract class - TypedBindingId that caries a types of the binding. In this case
when a programmer will try to use wrong ID in the module definition the compiler generates an error.

As an example, the BindingIdObjectsTest.scala is not compiled because it uses a wrong binding.

The injection is not implemented. If it is interesting I could finish the job.
