### PR TITLE
Added support for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ organization := "com.escalatesoft.subcut"
 
 version := "2.1.1-SNAPSHOT"
 
-crossScalaVersions := Seq("2.11.7", "2.10.5")
+crossScalaVersions := Seq("2.12.1", "2.11.7", "2.10.5")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.1"
 
 scalacOptions += "-deprecation"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (ver, deps) =>
   deps :+ "org.scala-lang" % "scala-compiler" % ver 


### PR DESCRIPTION
I added Scala 2.12 to the `crossScalaVersions` and updated ScalaTest to a version that exists for all three Scala versions.

It compiles and tests run successfully on a local machine.